### PR TITLE
Fix `octokit` usage

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,13 @@
+// @ts-check
+
+/**
+ * @type {typeof import('@actions/core')}
+ */
 const core = require('@actions/core');
+
+/**
+ * @type {typeof import('@actions/github')}
+ */
 const github = require('@actions/github');
 const fs = require('fs');
 
@@ -19,24 +28,24 @@ async function run() {
 
     const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/')
 
-    const token = core.getInput('repo-token', { required: true });
-    const octokit = new github.GitHub(token);
+    const token = core.getInput('repo-token', { required: true })
+    const octokit = github.getOctokit(token);
 
     const name = core.getInput('name', { required: true });
     const path = core.getInput('path', { required: true });
     const contentType = core.getInput('content-type', { required: true });
 
-    console.log(`Uploading ${path} to ${name} on release ${release_id} as Content-Type '${contentType}'`);
+    console.log(`Uploading ${path} to ${name} on release ${release_id} as Content-Type '${contentType}'`)
 
-    const { data: { upload_url: url } } = await octokit.repos.getRelease({owner, repo, release_id})
-    console.log(`Upload URL: ${url}`)
+    const { data: { upload_url: url } } = await octokit.rest.repos.getRelease({ owner, repo, release_id })
+    console.log(`Upload URL: ${url}`);
 
-    const { data: assets } = await octokit.repos.listAssetsForRelease({owner, repo, release_id})
+    const { data: assets } = await octokit.rest.repos.listReleaseAssets({owner,repo,release_id})
     assets.filter(asset => asset).forEach(({ id: asset_id, name: asset_name }) => {
         if (asset_name == name) {
-            octokit.repos.deleteReleaseAsset({owner, repo, asset_id})
+            octokit.rest.repos.deleteReleaseAsset({ owner, repo, asset_id })
         }
-    })
+    });
 
     const headers = {
         'content-type': contentType,
@@ -45,7 +54,15 @@ async function run() {
     const file = fs.createReadStream(path)
 
     // console.log(octokit.users.getAuthenticated())
-    const { data: { browser_download_url: browser_download_url }} = await octokit.repos.uploadReleaseAsset({url, headers, name, file})
+    const { data: { browser_download_url: browser_download_url }} = await octokit.rest.repos.uploadReleaseAsset({
+      owner,
+      repo,
+      release_id,
+      headers,
+      name,
+      // @ts-expect-error
+      data: file,
+    })
     console.log(`Download URL: ${browser_download_url}`)
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
Hoping this fixes the failures seen [here](https://github.com/Shopify/vscode-shopify-internal/actions/runs/18534400093/job/52825474222) - validated fix [here](https://github.com/Shopify/vscode-shopify-internal/actions/runs/18648615329/job/53161205292)

Alternatively I think this can be done though the GH cli 

```yml
permissions:
  contents: write

jobs:
  release:
    steps:
      - run: |
          gh release create v1.2.3 release.tar.xz
        env:
          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        shell: bash
        name: Creates a release in GitHub and uploads attachments
```